### PR TITLE
fix(prefab): convex collider warning 해결

### DIFF
--- a/Assets/07. Prefabs/1. Environment/Catapult.prefab
+++ b/Assets/07. Prefabs/1. Environment/Catapult.prefab
@@ -344,7 +344,6 @@ GameObject:
   - component: {fileID: 4237915153522452614}
   - component: {fileID: 705044620589644653}
   - component: {fileID: 7722163961289200014}
-  - component: {fileID: 5684116650161214360}
   m_Layer: 0
   m_Name: ForestCatapultArm
   m_TagString: Untagged
@@ -439,28 +438,6 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
---- !u!64 &5684116650161214360
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3389310463050096306}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &8034837514431395230
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Catapult 프리펩 하위의 구체 오브젝트에 Mesh 콜라이더가 포함되어 있어서 경고 발생. Sphere 콜라이더만 남기고 Mesh 콜라이더 제거해서 해결.